### PR TITLE
Fix blastx version in provenance

### DIFF
--- a/modules/snp_calling.nf
+++ b/modules/snp_calling.nf
@@ -21,7 +21,7 @@ process snp_calling {
     printf -- "- process_name: snp_caling\\n" >> ${sample_id}_snp_calling_provenance.yml
     printf -- "  tools:\\n"                   >> ${sample_id}_snp_calling_provenance.yml
     printf -- "    - tool_name: blastx\\n"    >> ${sample_id}_snp_calling_provenance.yml
-    printf -- "      tool_version: \$(blastx -version | head -n 1)\\n" >> ${sample_id}_snp_calling_provenance.yml
+    printf -- "      tool_version: \$(blastx -version | head -n 1 | cut -d ' ' -f 2)\\n" >> ${sample_id}_snp_calling_provenance.yml
     printf -- "  databases:\\n"               >> ${sample_id}_snp_calling_provenance.yml
     printf -- "    - database_name: ${blastx_db_name}\\n" >> ${sample_id}_snp_calling_provenance.yml
 

--- a/nextflow.config
+++ b/nextflow.config
@@ -1,7 +1,7 @@
 manifest {
   author = 'James Zlosnik (nextflow pipeline)/Kevin Kuchinski (FluViewer)'
   name = 'BCCDC-PHL/fluviewer-nf'
-  version = '0.2.2'
+  version = '0.3.0'
   description = 'BCCDC-PHL FluViewer'
   mainScript = 'main.nf'
   nextflowVersion = '>=20.01.0'


### PR DESCRIPTION
Fixes #32 

Also bumped pipeline version to `0.3.0` in preparation for next release.