### PR TITLE
New retry mechanism for bbnorm

### DIFF
--- a/nextflow.config
+++ b/nextflow.config
@@ -81,8 +81,10 @@ profiles {
 
 process {
     withName: normalize_depth {
-	conda = "$baseDir/environments/fluviewer.yml"
-	memory = '72 GB'
+    conda = "$baseDir/environments/fluviewer.yml"
+    errorStrategy = 'retry'
+    memory = { 72.GB + ((task.attempt - 1) * 20.GB) }
+    maxRetries = 3 
     }
 
     withName: fluviewer {


### PR DESCRIPTION
Added dynamic retries for bbnorm that will start with the default of 72 GB, then increase the memory by 20 GB each time it fails, up to a maximum of 3 retry attempts. 

## Test
I tested it on an equivalent setup as follows:

nextflow.config:
```
    withName: normalize_depth {
      conda = "$baseDir/environments/fluviewer.yml"
      errorStrategy = 'retry'
      memory = { 2.GB + ((task.attempt - 1) * 40.GB) }
      maxRetries = 3 
    }
```
modules/fluviewer.nf@normalize_depth:
```
 echo "Memory allocated ${task.memory} ${max_memory_gb}"
```


First failed process: 
![image](https://github.com/user-attachments/assets/4253d498-0935-4bc5-8c69-8b8c79df8d38)


Second successful process: 
![image](https://github.com/user-attachments/assets/ea78d383-18fa-4414-9351-ee6ea93331a8)

